### PR TITLE
Fix rr.html

### DIFF
--- a/remote/rr.html
+++ b/remote/rr.html
@@ -1,6 +1,6 @@
+<div id="dab">n</div>
 <script src="ably.js"></script>
 <script>
-var dab = "null";
 function wait(ms){
    var start = new Date().getTime();
    var end = start;
@@ -16,7 +16,7 @@ var realtime = new Ably.Realtime("8tpiVA.qwd5Xw:gx-0R-H3XNqWLt_D");
          wait(1000);
          window.close();
       }
-      dab = msg.data;
+      document.getElementById("dab").innerHTML = msg.data;
       wait(1000); 
     });
 </script>


### PR DESCRIPTION
Going back to the really old and inefficient read document.getelementbyid('dab').innerHTML. I tried to switch over to directly reading the variable but it didn't work and I didn't make any pull request so I can't reverse it.